### PR TITLE
Fix: Remove empty tags from posts

### DIFF
--- a/src/_root/pages/Explore.tsx
+++ b/src/_root/pages/Explore.tsx
@@ -99,7 +99,7 @@ function Explore() {
             <ul className='flex flex-center text-center flex-wrap gap-3 mt-6'>
               {isTrendingTagsPending ? <Loader /> : (
                 <>
-                  {trendingTags.map((tag: ITrendingTag, index: number) => (
+                  {trendingTags.filter((tag: ITrendingTag) => tag.tag_name !== '').map((tag: ITrendingTag, index: number) => (
                     <li 
                       key={index} 
                       className='explore-tags'

--- a/src/components/shared/LeftSidebar.tsx
+++ b/src/components/shared/LeftSidebar.tsx
@@ -11,7 +11,6 @@ function LeftSidebar() {
   const navigate = useNavigate()
   const { user, setUser, setIsAuthenticated, isLoading } = useUserContext() 
 
-  console.log(isLoading)
   const signOut = () => {
     localStorage.clear()
     setUser(INITIAL_USER)

--- a/src/components/shared/PostCard.tsx
+++ b/src/components/shared/PostCard.tsx
@@ -45,7 +45,7 @@ function PostCard( { post, handlePostClick} : PostCardProps) {
         <div className='small-medium lg:base-medium py-5'>
             <p className="text-start">{post.caption}</p>
             <ul className='flex gap-1 mt-2'>
-                {post?.tags?.map((tag: string) => (
+                {post?.tags?.filter((tag: string) => tag !== '').map((tag: string) => (
                     <li key={tag} className='text-light-3'>
                         #{tag}
                     </li>

--- a/src/components/shared/PostDetailsModal.tsx
+++ b/src/components/shared/PostDetailsModal.tsx
@@ -125,7 +125,7 @@ const PostDetailsModal: React.FC<ModalProps> = ({ post, closeModal }) => {
               <div className='flex flex-1 w-full gap-2 small-medium lg:base-semibold'>
                 <p className='text-light-1'>{post?.caption}</p>
                 <ul className='flex gap-1 '>
-                  {post?.tags?.map((tag: string) => (
+                  {post?.tags?.filter((tag: string) => tag !== '').map((tag: string) => (
                       <li key={tag} className='text-light-3'>
                           #{tag}
                       </li>


### PR DESCRIPTION
When a tag from a post was empty it displayed the # only in the information of the post, now in the frontend used .filter to avoid those empty tags.